### PR TITLE
Autodetect text files when converting line endings. (core.autocrlf=true)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
-# Set the default behavior, in case people don't have core.autocrlf set.
-* text eol=lf
+* text=auto


### PR DESCRIPTION
Rely on core.autocrlf=true, so all checked-out files are CRLF.
core.autocrlf=input (LF) causes VS to randomly convert files to CRLF, creating spurious diffs.