### PR TITLE
Properly reset N163 level when switching documents

### DIFF
--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -268,6 +268,8 @@ BOOL CFamiTrackerDoc::OnNewDocument()
 	if (!CDocument::OnNewDocument())
 		return FALSE;
 
+	// CFamiTrackerDoc::OnNewDocument calls CDocument::OnNewDocument() and CreateEmpty(). Both call DeleteContents.
+	// Opening files doesn't call CDocument::OnNewDocument() but calls CreateEmpty(). Only the latter calls DeleteContents.
 	CreateEmpty();
 
 	return TRUE;
@@ -452,6 +454,9 @@ void CFamiTrackerDoc::SetModifiedFlag(BOOL bModified)
 
 void CFamiTrackerDoc::CreateEmpty()
 {
+	// CFamiTrackerDoc::OnNewDocument calls CDocument::OnNewDocument() and CreateEmpty(). Both call DeleteContents.
+	// OpenDocument() doesn't call CDocument::OnNewDocument() but calls CreateEmpty(). Only the latter calls DeleteContents.
+
 	m_csDocumentLock.Lock();
 
 	// Allocate first song

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -402,15 +402,7 @@ void CFamiTrackerDoc::DeleteContents()
 	m_iExpansionChip = SNDCHIP_NONE;
 	m_iVibratoStyle = VIBRATO_OLD;
 	m_bLinearPitch = DEFAULT_LINEAR_PITCH;
-
-	// SetN163LevelOffset()
-		// If we're closing the program, tries to initialize a dead sound engine.
-		// If we're creating file, this gets called twice.
 	SetN163LevelOffset(0);
-		// If we're switching files, setting to 0 will fail to reinitialize the sound engine.
-	// If we set to INT_MIN, opening a file will reinitialize the sound engine unnecessarily.
-		// Honestly it doesn't matter.
-	// So leave it stale.
 
 	m_iChannelsAvailable = CHANNELS_DEFAULT;
 	m_iSpeedSplitPoint	 = DEFAULT_SPEED_SPLIT_POINT;

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -406,7 +406,7 @@ void CFamiTrackerDoc::DeleteContents()
 	// SetN163LevelOffset()
 		// If we're closing the program, tries to initialize a dead sound engine.
 		// If we're creating file, this gets called twice.
-	_N163LevelOffset = INT_MIN;
+	SetN163LevelOffset(0);
 		// If we're switching files, setting to 0 will fail to reinitialize the sound engine.
 	// If we set to INT_MIN, opening a file will reinitialize the sound engine unnecessarily.
 		// Honestly it doesn't matter.
@@ -529,11 +529,6 @@ void CFamiTrackerDoc::OnFileSaveAs()
 	theApp.GetSettings()->SetPath(newName, PATH_FTM);
 	
 	DoSave(newName);
-}
-
-bool CFamiTrackerDoc::isMainDocument() {
-	CFrameWnd *pFrameWnd = dynamic_cast<CFrameWnd*>(theApp.m_pMainWnd);
-	return pFrameWnd && pFrameWnd->GetActiveDocument() == this;
 }
 
 // CFamiTrackerDoc serialization (never used)
@@ -1355,9 +1350,7 @@ BOOL CFamiTrackerDoc::OpenDocument(LPCTSTR lpszPathName)
 	m_bFileLoadFailed = false;
 	m_bBackupDone = false;		// // //
 
-	if (isMainDocument()) {
-		theApp.GetSoundGenerator()->DocumentPropertiesChanged(this);
-	}
+	theApp.GetSoundGenerator()->DocumentPropertiesChanged(this);
 
 	return TRUE;
 }
@@ -4306,17 +4299,11 @@ int CFamiTrackerDoc::GetN163LevelOffset() const {
 	return _N163LevelOffset;
 }
 
+// DocumentPropertiesChanged calls GetN163LevelOffset and updates synth if modified.
 void CFamiTrackerDoc::SetN163LevelOffset(int offset) {
 	if (_N163LevelOffset != offset) {
 		ModifyIrreversible();
 		_N163LevelOffset = offset;
-		
-		if (isMainDocument()) {
-			theApp.LoadSoundConfig();	// CSoundGen::ResetAudioDevice looks at GetN163LevelOffset()
-			// TODO I should move N163 volume loading logic to DocumentPropertiesChanged? I'm not sure.
-			// TODO: theApp.GetSoundGenerator()->SetN163LevelOffset(offset)?
-			// Maybe I should pull out "primary FT doc connected to synth" and "imported FT doc" into separate classes.
-		}
 	}
 }
 

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -2613,7 +2613,7 @@ bool CFamiTrackerDoc::WriteBlock_ParamsExtra(CDocumentFile *pDocFile, const int 
 
 // FTM import ////
 
-CFamiTrackerDoc *CFamiTrackerDoc::LoadImportFile(LPCTSTR lpszPathName) const
+CFamiTrackerDoc *CFamiTrackerDoc::LoadImportFile(LPCTSTR lpszPathName)
 {
 	// Import a module as new subtunes
 	CFamiTrackerDoc *pImported = new CFamiTrackerDoc();

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -400,7 +400,7 @@ void CFamiTrackerDoc::DeleteContents()
 	m_iExpansionChip = SNDCHIP_NONE;
 	m_iVibratoStyle = VIBRATO_OLD;
 	m_bLinearPitch = DEFAULT_LINEAR_PITCH;
-	N163LevelOffset = 0;
+	SetN163LevelOffset(0);
 
 	m_iChannelsAvailable = CHANNELS_DEFAULT;
 	m_iSpeedSplitPoint	 = DEFAULT_SPEED_SPLIT_POINT;
@@ -461,7 +461,7 @@ void CFamiTrackerDoc::CreateEmpty()
 	// Auto-select new style vibrato for new modules
 	m_iVibratoStyle = VIBRATO_NEW;
 	m_bLinearPitch = DEFAULT_LINEAR_PITCH;
-	N163LevelOffset = 0;
+	SetN163LevelOffset(0);
 
 	m_iNamcoChannels = 0;		// // //
 
@@ -1308,7 +1308,7 @@ BOOL CFamiTrackerDoc::OpenDocument(LPCTSTR lpszPathName)
 			// Auto-select old style vibrato for old files
 			m_iVibratoStyle = VIBRATO_OLD;
 			m_bLinearPitch = false;
-			N163LevelOffset = 0;
+			SetN163LevelOffset(0);
 		}
 		else {
 			if (!OpenDocumentNew(OpenFile))
@@ -1356,7 +1356,7 @@ BOOL CFamiTrackerDoc::OpenDocumentOld(CFile *pOpenFile)
 
 	m_iVibratoStyle = VIBRATO_OLD;
 	m_bLinearPitch = false;
-	N163LevelOffset = 0;
+	SetN163LevelOffset(0);
 
 	// // // local structs
 	struct {
@@ -4283,13 +4283,13 @@ void CFamiTrackerDoc::SetLinearPitch(bool Enable)
 
 // N163 Volume Offset
 int CFamiTrackerDoc::GetN163LevelOffset() const {
-	return N163LevelOffset;
+	return _N163LevelOffset;
 }
 
 void CFamiTrackerDoc::SetN163LevelOffset(int offset) {
-	if (N163LevelOffset != offset) {
+	if (_N163LevelOffset != offset) {
 		ModifyIrreversible();
-		N163LevelOffset = offset;
+		_N163LevelOffset = offset;
 		theApp.LoadSoundConfig();
 	}
 }

--- a/Source/FamiTrackerDoc.h
+++ b/Source/FamiTrackerDoc.h
@@ -512,7 +512,7 @@ private:
 	unsigned int	m_iNamcoChannels;
 	vibrato_t		m_iVibratoStyle;							// 0 = old style, 1 = new style
 	bool			m_bLinearPitch;
-	int				N163LevelOffset;
+	int				_N163LevelOffset;
 	
 	machine_t		m_iMachine;									// // // NTSC / PAL
 	unsigned int	m_iEngineSpeed;								// Refresh rate

--- a/Source/FamiTrackerDoc.h
+++ b/Source/FamiTrackerDoc.h
@@ -571,6 +571,5 @@ protected:
 	DECLARE_MESSAGE_MAP()
 public:
 	afx_msg void OnFileSaveAs();
-	bool isMainDocument();
 	afx_msg void OnFileSave();
 };

--- a/Source/FamiTrackerDoc.h
+++ b/Source/FamiTrackerDoc.h
@@ -571,5 +571,6 @@ protected:
 	DECLARE_MESSAGE_MAP()
 public:
 	afx_msg void OnFileSaveAs();
+	bool isMainDocument();
 	afx_msg void OnFileSave();
 };

--- a/Source/FamiTrackerDoc.h
+++ b/Source/FamiTrackerDoc.h
@@ -118,7 +118,7 @@ public:
 	bool HasLastLoadFailed() const;
 
 	// Import
-	CFamiTrackerDoc* LoadImportFile(LPCTSTR lpszPathName) const;
+	static CFamiTrackerDoc* LoadImportFile(LPCTSTR lpszPathName);
 	bool ImportInstruments(CFamiTrackerDoc *pImported, int *pInstTable);
 	bool ImportGrooves(CFamiTrackerDoc *pImported, int *pGrooveMap);		// // //
 	bool ImportDetune(CFamiTrackerDoc *pImported);			// // //

--- a/Source/ModuleImportDlg.cpp
+++ b/Source/ModuleImportDlg.cpp
@@ -96,7 +96,7 @@ void CModuleImportDlg::OnBnClickedCancel()
 
 bool CModuleImportDlg::LoadFile(CString Path, CFamiTrackerDoc *pDoc)
 {	
-	m_pImportedDoc = pDoc->LoadImportFile(Path);
+	m_pImportedDoc = CFamiTrackerDoc::LoadImportFile(Path);
 
 	// Check if load failed
 	if (m_pImportedDoc == NULL)

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -364,6 +364,8 @@ CChannelHandler *CSoundGen::GetChannel(int Index) const
 
 void CSoundGen::DocumentPropertiesChanged(CFamiTrackerDoc *pDocument)
 {
+	if (pDocument != m_pDocument)
+		return;
 	ASSERT(pDocument != NULL);
 	
 	SetupVibratoTable(pDocument->GetVibratoStyle());		// // //

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -745,7 +745,7 @@ bool CSoundGen::ResetAudioDevice()
 	m_pAPU->SetChipLevel(CHIP_LEVEL_MMC5, float(pSettings->ChipLevels.iLevelMMC5 / 10.0f));
 	m_pAPU->SetChipLevel(CHIP_LEVEL_FDS, float(pSettings->ChipLevels.iLevelFDS / 10.0f));
 	m_pAPU->SetChipLevel(CHIP_LEVEL_N163, float(
-		(pSettings->ChipLevels.iLevelN163 + m_pDocument->GetN163LevelOffset())/ 10.0f));
+		(pSettings->ChipLevels.iLevelN163 + m_pDocument->GetN163LevelOffset()) / 10.0f));
 	m_pAPU->SetChipLevel(CHIP_LEVEL_S5B, float(pSettings->ChipLevels.iLevelS5B / 10.0f));
 /*
 	m_pAPU->SetChipLevel(SNDCHIP_NONE, 0);//pSettings->ChipLevels.iLevel2A03);

--- a/Source/SoundGen.cpp
+++ b/Source/SoundGen.cpp
@@ -139,7 +139,8 @@ CSoundGen::CSoundGen() :
 	m_pSequencePlayPos(NULL),
 	m_iSequencePlayPos(0),
 	m_iSequenceTimeout(0),
-	m_iBPMCachePosition(0)		// // //
+	m_iBPMCachePosition(0),		// // //
+	currN163LevelOffset(0)
 {
 	TRACE("SoundGen: Object created\n");
 
@@ -362,6 +363,16 @@ CChannelHandler *CSoundGen::GetChannel(int Index) const
 	return m_pChannels[Index];
 }
 
+/*
+INVARIANT: called whenever any document is created or changes.
+	CREATION:
+	CreateEmpty() calls DocumentPropertiesChanged.
+	OpenDocument() calls DocumentPropertiesChanged.
+
+PRECONDITION: pDocument is not null.
+PROPERTY: if pDocument is main document, linear pitch is synced.
+RESULT: linear pitch is correct.
+*/
 void CSoundGen::DocumentPropertiesChanged(CFamiTrackerDoc *pDocument)
 {
 	if (pDocument != m_pDocument)
@@ -531,6 +542,12 @@ void CSoundGen::DocumentPropertiesChanged(CFamiTrackerDoc *pDocument)
 	}
 	
 	m_iSpeedSplitPoint = pDocument->GetSpeedSplitPoint();
+
+	if (currN163LevelOffset != pDocument->GetN163LevelOffset()) {
+		// Player thread calls OnLoadSettings() which calls ResetAudioDevice()
+		// Why are GetCurrentThreadId and GetCurrentThread used interchangably?
+		LoadSettings();
+	}
 }
 
 //
@@ -740,6 +757,8 @@ bool CSoundGen::ResetAudioDevice()
 	if (!m_pAPU->SetupSound(SampleRate, 1, (m_iMachineType == NTSC) ? MACHINE_NTSC : MACHINE_PAL))
 		return false;
 
+	currN163LevelOffset = m_pDocument->GetN163LevelOffset();
+
 	m_pAPU->SetChipLevel(CHIP_LEVEL_APU1, float(pSettings->ChipLevels.iLevelAPU1 / 10.0f));
 	m_pAPU->SetChipLevel(CHIP_LEVEL_APU2, float(pSettings->ChipLevels.iLevelAPU2 / 10.0f));
 	m_pAPU->SetChipLevel(CHIP_LEVEL_VRC6, float(pSettings->ChipLevels.iLevelVRC6 / 10.0f));
@@ -747,7 +766,7 @@ bool CSoundGen::ResetAudioDevice()
 	m_pAPU->SetChipLevel(CHIP_LEVEL_MMC5, float(pSettings->ChipLevels.iLevelMMC5 / 10.0f));
 	m_pAPU->SetChipLevel(CHIP_LEVEL_FDS, float(pSettings->ChipLevels.iLevelFDS / 10.0f));
 	m_pAPU->SetChipLevel(CHIP_LEVEL_N163, float(
-		(pSettings->ChipLevels.iLevelN163 + m_pDocument->GetN163LevelOffset()) / 10.0f));
+		(pSettings->ChipLevels.iLevelN163 + currN163LevelOffset) / 10.0f));
 	m_pAPU->SetChipLevel(CHIP_LEVEL_S5B, float(pSettings->ChipLevels.iLevelS5B / 10.0f));
 /*
 	m_pAPU->SetChipLevel(SNDCHIP_NONE, 0);//pSettings->ChipLevels.iLevel2A03);

--- a/Source/SoundGen.h
+++ b/Source/SoundGen.h
@@ -298,6 +298,7 @@ private:
 	CDSoundChannel		*m_pDSoundChannel;
 	CVisualizerWnd		*m_pVisualizerWnd;
 	CAPU				*m_pAPU;
+	int currN163LevelOffset;
 
 	const CDSample		*m_pPreviewSample;
 


### PR DESCRIPTION
Properly reset N163 level when switching documents.

* If CFamiTrackerDoc::DeleteContents() calls SetN163LevelOffset(0) calls theApp.LoadSoundConfig():
  * Closing FT tries to reload a dead sound engine.
  * Opening a file reloads sound configuration multiple times.
* If we set _N163LevelOffset to 0 and SetN163LevelOffset(0) calls theApp.LoadSoundConfig():
  * Switching to a no-N163 file will fail to reinitialize the sound engine.
* If we set to INT_MIN, opening a file will reinitialize the sound engine unnecessarily.

Solution? Move N163 offset loading to CSoundGen::DocumentPropertiesChanged(document).

Fix bug, where cancelling a module import = changes vibrato and linear pitch in synth, but not module settings.