### PR TITLE
Disable N163 Zxx error checking.

### DIFF
--- a/Source/ChannelsN163.cpp
+++ b/Source/ChannelsN163.cpp
@@ -82,7 +82,6 @@ bool CChannelHandlerN163::HandleEffect(effect_t EffNum, unsigned char EffParam)
 			m_bDisableLoad = false;
 		}
 		else {
-			if (EffParam + (m_iWaveLen >> 1) > 0x80 - 8 * m_iChannels) break;
 			m_iWavePos = EffParam << 1;
 			m_bDisableLoad = true;
 		}


### PR DESCRIPTION
Zxx effects are processed before instruments load. 0CC mistakenly checked if the instrument 1 row ago would fit in the chosen position.

Fixes #3.