### PR TITLE
Calculate arrow-key step distance when moving cursor

### DIFF
--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -265,7 +265,6 @@ static int ConvertKeyExtra(int Key)		// // //
 
 CFamiTrackerView::CFamiTrackerView() : 
 	m_iClipboard(0),
-	m_iMoveKeyStepping(1),
 	m_iInsertKeyStepping(1),
 	m_bEditEnable(false),
 	m_bMaskInstrument(false),
@@ -2529,14 +2528,14 @@ void CFamiTrackerView::OnKeyUp(UINT nChar, UINT nRepCnt, UINT nFlags)
 void CFamiTrackerView::OnKeyDirUp()
 {
 	// Move up
-	m_pPatternEditor->MoveUp(m_iMoveKeyStepping);
+	m_pPatternEditor->MoveUp(MoveKeyStepping());
 	InvalidateCursor();
 }
 
 void CFamiTrackerView::OnKeyDirDown()
 {
 	// Move down
-	m_pPatternEditor->MoveDown(m_iMoveKeyStepping);
+	m_pPatternEditor->MoveDown(MoveKeyStepping());
 	InvalidateCursor();
 }
 
@@ -3576,13 +3575,16 @@ void CFamiTrackerView::OnDecreaseStepSize()
 void CFamiTrackerView::SetStepping(int Step) 
 { 
 	m_iInsertKeyStepping = Step;
-
-	if (Step > 0 && !theApp.GetSettings()->General.bNoStepMove)
-		m_iMoveKeyStepping = Step;
-	else 
-		m_iMoveKeyStepping = 1;
-
 	static_cast<CMainFrame*>(GetParentFrame())->UpdateControls();
+}
+
+unsigned CFamiTrackerView::MoveKeyStepping() const {
+	auto step = m_iInsertKeyStepping;
+	if (step > 0 && !theApp.GetSettings()->General.bNoStepMove) {
+		return step;
+	} else {
+		return 1;
+	}
 }
 
 void CFamiTrackerView::OnEditInterpolate()

--- a/Source/FamiTrackerView.h
+++ b/Source/FamiTrackerView.h
@@ -266,7 +266,7 @@ private:
 	int					m_iMenuChannel;							// Which channel a popup-menu belongs to
 
 	// Cursor & editing
-	unsigned int		m_iMoveKeyStepping;						// Number of rows to jump when moving
+	unsigned int MoveKeyStepping() const;
 	unsigned int		m_iInsertKeyStepping;					// Number of rows to move when inserting notes
 	bool				m_bEditEnable;							// Edit is enabled
 	bool				m_bSwitchToInstrument;					// Select active instrument


### PR DESCRIPTION
Fix bug #54 where "Ignore Step when moving" wouldn't take effect until changing step size.