### PR TITLE
Fix clcache debug builds

### DIFF
--- a/0CC-FamiTracker.vcxproj
+++ b/0CC-FamiTracker.vcxproj
@@ -78,6 +78,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -118,6 +119,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <AdditionalOptions>/FS %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
Fixes compilation errors with clcache.

You must edit Property Manager/Microsoft.Cpp.Win32.user dialog, VC++ Directories/Executable Directories to add clcache paths (preferably add /FS to compiler flags there too).

This will enable clcache (MUCH faster builds) globally.