### PR TITLE
Add =00 effect (VRC6 phase reset)

### DIFF
--- a/0CC-FamiTracker.vcxproj
+++ b/0CC-FamiTracker.vcxproj
@@ -216,6 +216,7 @@
     <ClCompile Include="Source\StretchDlg.cpp" />
     <ClCompile Include="Source\SwapDlg.cpp" />
     <ClCompile Include="Source\TransposeDlg.cpp" />
+    <ClCompile Include="Source\utils\input.cpp" />
     <ClCompile Include="Source\VisualizerBase.cpp" />
     <ClCompile Include="Source\WaveEditor.cpp" />
     <ClCompile Include="Source\GraphEditor.cpp" />
@@ -426,6 +427,7 @@
     <ClInclude Include="Source\type_safe\types.hpp" />
     <ClInclude Include="Source\type_safe\variant.hpp" />
     <ClInclude Include="Source\type_safe\visitor.hpp" />
+    <ClInclude Include="Source\utils\input.h" />
     <ClInclude Include="Source\VisualizerBase.h" />
     <ClInclude Include="Source\WaveformGenerator.h" />
     <ClInclude Include="Source\WavegenBuiltin.h" />

--- a/0CC-FamiTracker.vcxproj
+++ b/0CC-FamiTracker.vcxproj
@@ -216,7 +216,6 @@
     <ClCompile Include="Source\StretchDlg.cpp" />
     <ClCompile Include="Source\SwapDlg.cpp" />
     <ClCompile Include="Source\TransposeDlg.cpp" />
-    <ClCompile Include="Source\utils\input.cpp" />
     <ClCompile Include="Source\VisualizerBase.cpp" />
     <ClCompile Include="Source\WaveEditor.cpp" />
     <ClCompile Include="Source\GraphEditor.cpp" />

--- a/0CC-FamiTracker.vcxproj.filters
+++ b/0CC-FamiTracker.vcxproj.filters
@@ -226,6 +226,12 @@
     <Filter Include="Header Files\Windows Headers">
       <UniqueIdentifier>{4cc7efc0-6478-4fe0-ab32-cd34c48e735a}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Header Files\utils">
+      <UniqueIdentifier>{d048192f-ce5d-455d-84ee-c9609fffd270}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files\utils">
+      <UniqueIdentifier>{5b5628bb-0b1c-41b9-919d-73689e71d621}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Source\Exception.cpp">
@@ -716,6 +722,9 @@
     </ClCompile>
     <ClCompile Include="Source\NoNotifyEdit.cpp">
       <Filter>Source Files\Custom Controls</Filter>
+    </ClCompile>
+    <ClCompile Include="Source\utils\input.cpp">
+      <Filter>Source Files\utils</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -1321,6 +1330,9 @@
     </ClInclude>
     <ClInclude Include="Source\array_view.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Source\utils\input.h">
+      <Filter>Header Files\utils</Filter>
     </ClInclude>
     <ClInclude Include="Source\type_safe\detail\aligned_union.hpp">
       <Filter>Header Files</Filter>

--- a/0CC-FamiTracker.vcxproj.filters
+++ b/0CC-FamiTracker.vcxproj.filters
@@ -723,9 +723,6 @@
     <ClCompile Include="Source\NoNotifyEdit.cpp">
       <Filter>Source Files\Custom Controls</Filter>
     </ClCompile>
-    <ClCompile Include="Source\utils\input.cpp">
-      <Filter>Source Files\utils</Filter>
-    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Source\Exception.h">

--- a/Source/APU/VRC6.CPP
+++ b/Source/APU/VRC6.CPP
@@ -57,6 +57,10 @@ void CVRC6_Pulse::Write(uint16_t Address, uint8_t Value)
 			m_iPeriod = m_iPeriodLow + (m_iPeriodHigh << 8);
 			break;
 		case 0x02:
+			// Continuously reset phase when disabled.
+			if (!this->m_iEnabled) {
+				m_iDutyCycleCounter = 0;	// Coarse counter, period=32
+			}
 			m_iEnabled = (Value & 0x80);
 			m_iPeriodHigh = (Value & 0x0F);
 			m_iPeriod = m_iPeriodLow + (m_iPeriodHigh << 8);
@@ -118,6 +122,15 @@ void CVRC6_Sawtooth::Write(uint16_t Address, uint8_t Value)
 			m_iPeriod = m_iPeriodLow + (m_iPeriodHigh << 8);
 			break;
 		case 0x02:
+			// Continuously reset phase when disabled.
+			if (!this->m_iEnabled) {
+				// m_iCounter = 0;	// Fine counter. "Clearing E does not reset the frequency divider, however"
+					// Also, assigning to 0 would be wrong since it counts *down*, so 0 triggers an immediate step.
+				// Not resetting fine-phase (m_iCounter) creates deliberate jitter of up to 1/7 cycle.
+				
+				m_iResetReg = 0;			// Coarse counter, period=14. `count14 = 0`
+				m_iPhaseAccumulator = 0;	// sawtooth numeric output.
+			}
 			m_iEnabled = (Value & 0x80);
 			m_iPeriodHigh = (Value & 0x0F);
 			m_iPeriod = m_iPeriodLow + (m_iPeriodHigh << 8);

--- a/Source/APU/VRC6.CPP
+++ b/Source/APU/VRC6.CPP
@@ -60,6 +60,7 @@ void CVRC6_Pulse::Write(uint16_t Address, uint8_t Value)
 			// Continuously reset phase when disabled.
 			if (!this->m_iEnabled) {
 				m_iDutyCycleCounter = 0;	// Coarse counter, period=32
+				// For hardware-accuracy, do not reset fine counter `m_iCounter = 0`.
 			}
 			m_iEnabled = (Value & 0x80);
 			m_iPeriodHigh = (Value & 0x0F);
@@ -124,12 +125,13 @@ void CVRC6_Sawtooth::Write(uint16_t Address, uint8_t Value)
 		case 0x02:
 			// Continuously reset phase when disabled.
 			if (!this->m_iEnabled) {
-				// m_iCounter = 0;	// Fine counter. "Clearing E does not reset the frequency divider, however"
-					// Also, assigning to 0 would be wrong since it counts *down*, so 0 triggers an immediate step.
-				// Not resetting fine-phase (m_iCounter) creates deliberate jitter of up to 1/7 cycle.
-				
-				m_iResetReg = 0;			// Coarse counter, period=14. `count14 = 0`
+				m_iResetReg = 0;			// Coarse counter, period=14. (NSFPlay: `count14 = 0`)
 				m_iPhaseAccumulator = 0;	// sawtooth numeric output.
+
+				// For hardware-accuracy, do not reset fine counter `m_iCounter = 0`.
+				// Also, assigning to 0 would be wrong since it counts *down*, so 0 triggers an immediate step.
+
+				// Not resetting m_iCounter creates deliberate jitter of up to 1/7 cycle.
 			}
 			m_iEnabled = (Value & 0x80);
 			m_iPeriodHigh = (Value & 0x0F);

--- a/Source/ChannelHandler.cpp
+++ b/Source/ChannelHandler.cpp
@@ -953,7 +953,7 @@ void CChannelHandler::AddCycles(int count)
 void CChannelHandler::WriteRegister(uint16_t Reg, uint8_t Value)
 {
 	m_pAPU->Write(Reg, Value);
-	m_pSoundGen->WriteRegister(Reg, Value);
+	m_pSoundGen->WriteRegister(Reg, Value);		// This method is dead. Blame #ifdef WRITE_VGM.
 }
 
 void CChannelHandler::RegisterKeyState(int Note)

--- a/Source/ChannelsVRC6.cpp
+++ b/Source/ChannelsVRC6.cpp
@@ -45,6 +45,10 @@ bool CChannelHandlerVRC6::HandleEffect(effect_t EffNum, unsigned char EffParam)
 	case EF_DUTY_CYCLE:
 		m_iDefaultDuty = m_iDutyPeriod = EffParam;
 		break;
+
+	case EF_PHASE_RESET:
+		this->ClearRegisters();		// TODO ensure this doesn't interrupt for 1 frame.
+		break;
 	default: return CChannelHandler::HandleEffect(EffNum, EffParam);
 	}
 

--- a/Source/ChannelsVRC6.cpp
+++ b/Source/ChannelsVRC6.cpp
@@ -47,9 +47,11 @@ bool CChannelHandlerVRC6::HandleEffect(effect_t EffNum, unsigned char EffParam)
 		break;
 
 	case EF_PHASE_RESET:
-		this->resetPhase();
-		// RefreshChannel gets called afterwards, on the same frame.
-		// So there is no 1-frame silent gap (verified while running at 16hz).
+		if (EffParam == 0) {
+			this->resetPhase();
+			// RefreshChannel gets called afterwards, on the same frame.
+			// So there is no 1-frame silent gap (verified while running at 16hz).
+		}
 		break;
 	default: return CChannelHandler::HandleEffect(EffNum, EffParam);
 	}

--- a/Source/ChannelsVRC6.cpp
+++ b/Source/ChannelsVRC6.cpp
@@ -47,7 +47,9 @@ bool CChannelHandlerVRC6::HandleEffect(effect_t EffNum, unsigned char EffParam)
 		break;
 
 	case EF_PHASE_RESET:
-		this->ClearRegisters();		// TODO ensure this doesn't interrupt for 1 frame.
+		this->resetPhase();
+		// RefreshChannel gets called afterwards, on the same frame.
+		// So there is no 1-frame silent gap (verified while running at 16hz).
 		break;
 	default: return CChannelHandler::HandleEffect(EffNum, EffParam);
 	}
@@ -84,11 +86,22 @@ bool CChannelHandlerVRC6::CreateInstHandler(inst_type_t Type)
 	return false;
 }
 
+
+uint16_t CChannelHandlerVRC6::getAddress() {
+	return ((m_iChannelID - CHANID_VRC6_PULSE1) << 12) + 0x9000;
+}
+
 void CChannelHandlerVRC6::ClearRegisters()		// // //
 {
-	uint16_t Address = ((m_iChannelID - CHANID_VRC6_PULSE1) << 12) + 0x9000;
+	uint16_t Address = this->getAddress();
 	WriteRegister(Address, 0);
 	WriteRegister(Address + 1, 0);
+	WriteRegister(Address + 2, 0);
+}
+
+void CChannelHandlerVRC6::resetPhase()		// // //
+{
+	uint16_t Address = this->getAddress();
 	WriteRegister(Address + 2, 0);
 }
 
@@ -98,7 +111,7 @@ void CChannelHandlerVRC6::ClearRegisters()		// // //
 
 void CVRC6Square::RefreshChannel()
 {
-	uint16_t Address = ((m_iChannelID - CHANID_VRC6_PULSE1) << 12) + 0x9000;
+	uint16_t Address = this->getAddress();
 
 	unsigned int Period = CalculatePeriod();
 	unsigned int Volume = CalculateVolume();

--- a/Source/ChannelsVRC6.h
+++ b/Source/ChannelsVRC6.h
@@ -38,7 +38,9 @@ protected:
 	void	HandleRelease() override;
 	bool	CreateInstHandler(inst_type_t Type) override;		// // //
 	// // //
+	uint16_t getAddress();
 	void	ClearRegisters() override;		// // //
+	void	resetPhase();
 };
 
 class CVRC6Square : public CChannelHandlerVRC6 {

--- a/Source/FamiTrackerDoc.cpp
+++ b/Source/FamiTrackerDoc.cpp
@@ -4918,7 +4918,8 @@ stFullState *CFamiTrackerDoc::RetrieveSoundState(unsigned int Track, unsigned in
 			CTrackerChannel *ch = GetChannel(c);
 			ASSERT(ch != NULL);
 			for (int k = EffColumns; k >= 0; k--) {
-				unsigned char fx = Note.EffNumber[k], xy = Note.EffParam[k];
+				effect_t fx = Note.EffNumber[k];
+				unsigned char xy = Note.EffParam[k];
 				switch (fx) {
 				// ignore effects that cannot have memory
 				case EF_NONE: case EF_PORTAOFF:

--- a/Source/FamiTrackerTypes.h
+++ b/Source/FamiTrackerTypes.h
@@ -171,24 +171,13 @@ enum effect_t : unsigned char {
 	EF_N163_WAVE_BUFFER,	// // // N163 wave buffer
 	EF_FDS_VOLUME,      	// // // FDS volume envelope
 	EF_FDS_MOD_BIAS,    	// // // FDS auto-FM bias
-	// EF_TARGET_VOLUME_SLIDE,
-/*
-	EF_VRC7_MODULATOR,
-	EF_VRC7_CARRIER,
-	EF_VRC7_LEVELS,
-*/
+
+	// jimbo1qaz
+	EF_PHASE_RESET,			// 
+
 	EF_COUNT
 };
 
-// DPCM  effects
-//const int EF_DPCM_PITCH = EF_SWEEPUP;		// DPCM pitch, 'H'
-
-//const int EF_VRC7_PATCH = EF_DUTY_CYCLE;	// VRC7 patch setting, 'V'
-
-// FDS effects
-//const int EF_FDS_MOD_DEPTH = EF_SWEEPUP;	// FDS modulation depth, 'H'
-
-//const int EF_RETRIGGER = EF_SWEEPDOWN;
 // Note: Order must be preserved.
 // Global/2A03 effects should be listed before expansion-specific effects
 // sharing the same character.
@@ -244,12 +233,9 @@ const char EFF_CHAR[] = {
 	'Z',   	// EF_N163_WAVE_BUFFER,
 	'E',   	// EF_FDS_VOLUME,
 	'Z',   	// EF_FDS_MOD_BIAS,
-	//'9'  	// EF_TARGET_VOLUME_SLIDE,
-	/*
-	'H',	// EF_VRC7_MODULATOR,
-	'I',	// EF_VRC7_CARRIER,
-	'J',	// EF_VRC7_LEVELS,
-	*/
+
+	// jimbo1qaz
+	'=',	// EF_PHASE_RESET
 };
 
 struct Effect {

--- a/Source/FamiTrackerTypes.h
+++ b/Source/FamiTrackerTypes.h
@@ -112,20 +112,6 @@ enum sequence_t {
 	SEQ_COUNT
 };
 
-// New sequence types
-/*
-enum {
-	SEQ_VOLUME,
-	SEQ_ARPEGGIO,
-	SEQ_PITCH,
-	SEQ_HIPITCH,		// TODO: remove this eventually
-	SEQ_DUTYCYCLE,
-	SEQ_SUNSOFT_NOISE,
-
-	SEQ_COUNT
-};
-*/
-//const int SEQ_SUNSOFT_NOISE = SEQ_DUTYCYCLE + 1;
 
 // Channel effects
 enum effect_t : unsigned char {
@@ -188,6 +174,8 @@ const effect_t FDS_EFFECTS[] = {EF_FDS_MOD_DEPTH, EF_FDS_MOD_SPEED_HI, EF_FDS_MO
 // const effect_t MMC5_EFFECTS[] = {};
 const effect_t N163_EFFECTS[] = {EF_N163_WAVE_BUFFER};
 const effect_t S5B_EFFECTS[] = {EF_SUNSOFT_ENV_TYPE, EF_SUNSOFT_ENV_HI, EF_SUNSOFT_ENV_LO, EF_SUNSOFT_NOISE};
+
+// Effect checking = bool CTrackerChannel::IsEffectCompatible
 
 // Channel effect letters
 const char EFF_CHAR[] = {

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -50,7 +50,6 @@
 #include <cmath>
 #include <assert.h>
 
-using std::get;
 using std::get_if;
 
 #ifdef _DEBUG

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -46,6 +46,7 @@
 #include "RecordSettingsDlg.h"
 #include "SplitKeyboardDlg.h"
 #include "NoteQueue.h"
+#include <assert.h>
 
 #ifdef _DEBUG
 #define new DEBUG_NEW
@@ -138,8 +139,11 @@ BEGIN_MESSAGE_MAP(CFamiTrackerView, CView)
 	ON_WM_TIMER()
 	ON_WM_VSCROLL()
 	ON_WM_HSCROLL()
+	
 	ON_WM_KEYDOWN()
+	ON_WM_CHAR()
 	ON_WM_KEYUP()
+	
 	ON_WM_MOUSEMOVE()
 	ON_WM_MOUSEWHEEL()
 	ON_WM_LBUTTONDOWN()
@@ -2409,6 +2413,7 @@ bool CFamiTrackerView::IsControlPressed() const
 	return (::GetKeyState(VK_CONTROL) & 0x80) == 0x80;
 }
 
+// OnKeyDown accepts virtual keycodes, and handles most input.
 void CFamiTrackerView::OnKeyDown(UINT key, UINT nRepCnt, UINT nFlags)
 {	
 	// Called when a key is pressed
@@ -2428,7 +2433,7 @@ void CFamiTrackerView::OnKeyDown(UINT key, UINT nRepCnt, UINT nFlags)
 	}
 
 	if ((key == VK_ADD || key == VK_SUBTRACT) && theApp.GetSettings()->General.bHexKeypad)		// // //
-		HandleKeyboardInput(key);
+		HandleKeyboardInput(key, KeyType::KEYCODE);
 	else if (!theApp.GetSettings()->General.bHexKeypad || !(key == VK_RETURN && !(nFlags & KF_EXTENDED))) switch (key) {
 		case VK_UP:
 			OnKeyDirUp();
@@ -2485,10 +2490,62 @@ void CFamiTrackerView::OnKeyDown(UINT key, UINT nRepCnt, UINT nFlags)
 		case VK_F9: pFrame->SelectOctave(7); break;
 
 		default:
-			HandleKeyboardInput(key);
+			HandleKeyboardInput(key, KeyType::KEYCODE);
 	}
 
 	CView::OnKeyDown(key, nRepCnt, nFlags);
+}
+
+
+bool withinInclusive(int x, int first, int last) {
+	return first <= x && x <= last;
+}
+
+template <typename T>
+bool isAlphanumeric(T x) {
+	auto num = static_cast<int>(x);
+	return withinInclusive(num, 'A', 'Z')
+		|| withinInclusive(num, 'a', 'z')
+		|| withinInclusive(num, '0', '9');
+}
+
+// OnChar operates on translated characters, and inserts non-alphanumeric effects.
+void CFamiTrackerView::OnChar(UINT chr, UINT nrepeat, UINT flags) {
+	if (GetFocus() != this)
+		return;
+
+	// don't handle standard effects
+	if (isAlphanumeric(chr)) {
+		return;
+	}
+
+	// Don't repeat effect, if key repeat disabled
+	if (nrepeat && !(theApp.GetSettings()->General.bKeyRepeat)) {
+		return;
+	}
+
+	//int track = static_cast<CMainFrame*>(GetParentFrame())->GetSelectedTrack();
+	//int frame = m_pPatternEditor->GetFrame();
+	//int row = m_pPatternEditor->GetRow();
+	//int channel = m_pPatternEditor->GetChannel();
+	//
+	//cursor_column_t column = m_pPatternEditor->GetColumn();
+
+	//// Only handle effect columns.
+	//const int DELTA = C_EFF2_NUM - C_EFF1_NUM;
+	//if (column >= C_EFF1_NUM) {
+	//	int offset = column - C_EFF1_NUM;
+	//	int index = column / DELTA;
+	//	offset %= DELTA;
+
+	//	// Only handle effect name column.
+	//	if (offset == 0) {
+	//		this->EditEffNumberColumn();
+	//	}
+	//}
+	//return;
+
+	HandleKeyboardInput(chr, KeyType::CHARACTER);
 }
 
 void CFamiTrackerView::OnSysKeyDown(UINT key, UINT nRepCnt, UINT nFlags)
@@ -2789,28 +2846,40 @@ bool CFamiTrackerView::EditVolumeColumn(stChanNote &Note, Keycode Key, bool &bSt
 	return true;
 }
 
-bool CFamiTrackerView::EditEffNumberColumn(stChanNote &Note, Keycode key, int EffectIndex, bool &bStepDown)
+bool CFamiTrackerView::EditEffNumberColumn(stChanNote &Note, Keycode key, KeyType type, int EffectIndex, bool &bStepDown)
 {
 	int EditStyle = theApp.GetSettings()->General.iEditStyle;
 
 	if (!m_bEditEnable)
 		return false;
 
-	if (CheckRepeatKey(key)) {
-		Note.EffNumber[EffectIndex] = m_iLastEffect;
-		Note.EffParam[EffectIndex] = m_iLastEffectParam;
-		if (EditStyle != EDIT_STYLE_MPT)		// // //
-			bStepDown = true;
-		if (m_bEditEnable && Note.EffNumber[EffectIndex] != EF_NONE)		// // //
-			GetParentFrame()->SetMessageText(GetEffectHint(Note, EffectIndex));
-		return true;
-	}
+	if (type == KeyType::KEYCODE) {
+		// class InputKey -> isKey, isChar
+		// if input.isKey():
+		// KeyType key = input.getKey();
 
-	if (CheckClearKey(key)) {
-		Note.EffNumber[EffectIndex] = EF_NONE;
-		if (EditStyle != EDIT_STYLE_MPT)
-			bStepDown = true;
-		return true;
+		// union input;
+		// if type == KEYCODE: KeyType key = input;
+
+		if (CheckRepeatKey(key)) {
+			Note.EffNumber[EffectIndex] = m_iLastEffect;
+			Note.EffParam[EffectIndex] = m_iLastEffectParam;
+			if (EditStyle != EDIT_STYLE_MPT)		// // //
+				bStepDown = true;
+			if (m_bEditEnable && Note.EffNumber[EffectIndex] != EF_NONE)		// // //
+				GetParentFrame()->SetMessageText(GetEffectHint(Note, EffectIndex));
+			return true;
+		}
+
+		if (CheckClearKey(key)) {
+			Note.EffNumber[EffectIndex] = EF_NONE;
+			if (EditStyle != EDIT_STYLE_MPT)
+				bStepDown = true;
+			return true;
+		}
+
+		if (key >= VK_NUMPAD0 && key <= VK_NUMPAD9)
+			key = '0' + (key - VK_NUMPAD0);
 	}
 
 	CFamiTrackerDoc* pDoc = GetDocument();
@@ -2818,8 +2887,15 @@ bool CFamiTrackerView::EditEffNumberColumn(stChanNote &Note, Keycode key, int Ef
 
 	int Chip = pDoc->GetChannel(m_pPatternEditor->GetChannel())->GetChip();
 
-	if (key >= VK_NUMPAD0 && key <= VK_NUMPAD9)
-		key = '0' + key - VK_NUMPAD0;
+
+	// **** Handle effect names. ****
+
+	if (type == KeyType::KEYCODE && !isAlphanumeric(key)) {
+		return false;
+	}
+	if (type == KeyType::CHARACTER) {
+		assert(!isAlphanumeric(key));
+	}
 
 	bool bValidEffect = false;
 	effect_t Effect = GetEffectFromChar(static_cast<char>(key), Chip, &bValidEffect);		// // //
@@ -2920,9 +2996,17 @@ bool CFamiTrackerView::EditEffParamColumn(stChanNote &Note, Keycode Key, int Eff
 	return true;
 }
 
-void CFamiTrackerView::HandleKeyboardInput(Keycode Key)
+void CFamiTrackerView::HandleKeyboardInput(Keycode Key, KeyType type)
 {
-	if (theApp.GetAccelerator()->IsKeyUsed(static_cast<int>(Key))) return;		// // //
+	// https://github.com/solodon4/Mach7 ???
+	if (type == KeyType::KEYCODE) {
+		if (theApp.GetAccelerator()->IsKeyUsed(static_cast<int>(Key)))
+			return;
+
+		// Watch for repeating keys
+		if (PreventRepeat(Key, m_bEditEnable))
+			return;
+	}
 
 	CFamiTrackerDoc* pDoc = GetDocument();
 	ASSERT_VALID(pDoc);
@@ -2942,9 +3026,6 @@ void CFamiTrackerView::HandleKeyboardInput(Keycode Key)
 	bool bMoveRight = false;
 	bool bMoveLeft = false;
 
-	// Watch for repeating keys
-	if (PreventRepeat(Key, m_bEditEnable))
-		return;
 
 	// Get the note data
 	pDoc->GetNoteData(Track, Frame, Channel, Row, &Note);
@@ -2965,45 +3046,41 @@ void CFamiTrackerView::HandleKeyboardInput(Keycode Key)
 		case C_EFF4_PARAM2:	Column = C_EFF1_PARAM2; Index = 3; break;
 	}
 
-	if (Column != C_NOTE && !m_bEditEnable)		// // //
-		HandleKeyboardNote(Key, true);
-	switch (Column) {
+	if (type == KeyType::KEYCODE) {
+
+		if (Column != C_NOTE && !m_bEditEnable)		// // //
+			HandleKeyboardNote(Key, true);
+
+		switch (Column) {
 		// Note & octave column
 		case C_NOTE:
 			if (CheckRepeatKey(Key)) {
 				if (m_iLastNote == 0) {
 					Note.Note = 0;
-				}
-				else if (m_iLastNote == NOTE_HALT) {
+				} else if (m_iLastNote == NOTE_HALT) {
 					Note.Note = HALT;
-				}
-				else if (m_iLastNote == NOTE_RELEASE) {
+				} else if (m_iLastNote == NOTE_RELEASE) {
 					Note.Note = RELEASE;
-				}
-				else if (m_iLastNote >= NOTE_ECHO && m_iLastNote <= NOTE_ECHO + ECHO_BUFFER_LENGTH) {		// // //
+				} else if (m_iLastNote >= NOTE_ECHO && m_iLastNote <= NOTE_ECHO + ECHO_BUFFER_LENGTH) {		// // //
 					Note.Note = ECHO;
 					Note.Octave = m_iLastNote - NOTE_ECHO;
-				}
-				else {
+				} else {
 					Note.Note = GET_NOTE(m_iLastNote);
 					Note.Octave = GET_OCTAVE(m_iLastNote);
 				}
-			}
-			else if (CheckEchoKey(Key)) {		// // //
+			} else if (CheckEchoKey(Key)) {		// // //
 				Note.Note = ECHO;
 				Note.Octave = static_cast<CMainFrame*>(GetParentFrame())->GetSelectedOctave();		// // //
 				if (Note.Octave > ECHO_BUFFER_LENGTH) Note.Octave = ECHO_BUFFER_LENGTH;
 				if (!m_bMaskInstrument)
 					Note.Instrument = GetInstrument();
 				m_iLastNote = NOTE_ECHO + Note.Octave;
-			}
-			else if (CheckClearKey(Key)) {
+			} else if (CheckClearKey(Key)) {
 				// Remove note
 				Note.Note = 0;
 				Note.Octave = 0;
 				m_iLastNote = 0;
-			}
-			else {
+			} else {
 				// This is special
 				HandleKeyboardNote(Key, true);
 				return;
@@ -3011,10 +3088,13 @@ void CFamiTrackerView::HandleKeyboardInput(Keycode Key)
 			if (EditStyle != EDIT_STYLE_MPT)		// // //
 				bStepDown = true;
 			break;
+
+		// TODO isAlphanumeric
+
 		// Instrument column
 		case C_INSTRUMENT1:
 		case C_INSTRUMENT2:
-			if (!EditInstrumentColumn(Note, Key, bStepDown, bMoveRight, bMoveLeft))
+			if (!EditInstrumentColumn(Note, Key, bStepDown, bMoveRight, bMoveLeft))		// invert test?
 				return;
 			break;
 		// Volume column
@@ -3024,7 +3104,7 @@ void CFamiTrackerView::HandleKeyboardInput(Keycode Key)
 			break;
 		// Effect type (character)
 		case C_EFF1_NUM:
-			if (!EditEffNumberColumn(Note, Key, Index, bStepDown))
+			if (!EditEffNumberColumn(Note, Key, type, Index, bStepDown))
 				return;
 			break;
 		// Effect parameter
@@ -3033,10 +3113,21 @@ void CFamiTrackerView::HandleKeyboardInput(Keycode Key)
 			if (!EditEffParamColumn(Note, Key, Index, bStepDown, bMoveRight, bMoveLeft))
 				return;
 			break;
-	}
+		}
 
-	if (CheckClearKey(Key) && IsControlPressed())		// // //
-		Note = stChanNote { };
+		if (CheckClearKey(Key) && IsControlPressed())		// // //
+			Note = stChanNote{};
+	}
+	else if (type == KeyType::CHARACTER) {
+		if (Column == C_EFF1_NUM) {
+			if (EditEffNumberColumn(Note, Key, type, Index, bStepDown)) {
+				goto altered_char;
+			}
+		}
+		return;
+
+		altered_char:
+	}
 
 	// Something changed, store pattern data in document and update screen
 	if (m_bEditEnable) {

--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -115,6 +115,7 @@ const CString EFFECT_TEXTS[] = {		// // //
 	_T("Exx - FDS volume envelope (attack), XX = rate"),
 	_T("Exx - FDS volume envelope (decay), XX - 40 = rate"),
 	_T("Zxx - Auto FDS modulation rate bias, XX - 80 = offset"),
+	_T("=00 - Reset channel phase"),
 };
 
 // OLE copy and mix

--- a/Source/FamiTrackerView.h
+++ b/Source/FamiTrackerView.h
@@ -30,7 +30,7 @@
 
 #include "PatternEditorTypes.h"		// // //
 #include "FamiTrackerViewMessage.h"		// // //
-#include <stdint.h>
+#include "utils/input.h"
 
 // External classes
 class CFamiTrackerDoc;
@@ -38,16 +38,6 @@ class CPatternEditor;
 class CFrameEditor;
 class Action;
 class CNoteQueue;		// // //
-
-// Keycode vs character
-
-using Keycode = int64_t;// int
-using Character = uint64_t;
-
-enum class KeyType {
-	KEYCODE,
-	CHARACTER
-};
 
 // TODO move general tracker state variables to the mainframe instead of the view, such as selected octave, instrument etc
 
@@ -178,7 +168,7 @@ private:
 	void	StepDown();
 
 	// Input key handling
-	void HandleKeyboardInput(Keycode Key, KeyType type);		// // //
+	void HandleKeyboardInput(Input input);
 	void	TranslateMidiMessage();
 
 	void	OnKeyDirUp();
@@ -214,7 +204,7 @@ private:
 
 	bool	EditInstrumentColumn(stChanNote &Note, Keycode key, bool &StepDown, bool &MoveRight, bool &MoveLeft);
 	bool	EditVolumeColumn(stChanNote &Note, Keycode key, bool &bStepDown);
-	bool EditEffNumberColumn(stChanNote &Note, Keycode key, KeyType type, int EffectIndex, bool &bStepDown);
+	bool	EditEffNumberColumn(stChanNote &Note, Input input, int EffectIndex, bool &bStepDown);
 	bool	EditEffParamColumn(stChanNote &Note, Keycode key, int EffectIndex, bool &bStepDown, bool &bMoveRight, bool &bMoveLeft);
 
 	void	InsertNote(int Note, int Octave, int Channel, int Velocity);

--- a/Source/FamiTrackerView.h
+++ b/Source/FamiTrackerView.h
@@ -30,6 +30,7 @@
 
 #include "PatternEditorTypes.h"		// // //
 #include "FamiTrackerViewMessage.h"		// // //
+#include <stdint.h>
 
 // External classes
 class CFamiTrackerDoc;
@@ -37,6 +38,8 @@ class CPatternEditor;
 class CFrameEditor;
 class Action;
 class CNoteQueue;		// // //
+
+using Keycode = int64_t;// int
 
 // TODO move general tracker state variables to the mainframe instead of the view, such as selected octave, instrument etc
 
@@ -104,8 +107,8 @@ public:
 	void		 RegisterKeyState(int Channel, int Note);
 
 	// Note preview
-	bool		 PreviewNote(unsigned char Key);
-	void		 PreviewRelease(unsigned char Key);
+	bool		 PreviewNote(Keycode Key);
+	void		 PreviewRelease(Keycode Key);
 
 	// Mute methods
 	void		 SoloChannel(unsigned int Channel);
@@ -167,7 +170,7 @@ private:
 	void	StepDown();
 
 	// Input key handling
-	void	HandleKeyboardInput(unsigned char Key);		// // //
+	void	HandleKeyboardInput(Keycode Key);		// // //
 	void	TranslateMidiMessage();
 
 	void	OnKeyDirUp();
@@ -188,28 +191,28 @@ private:
 	void	KeyIncreaseAction();
 	void	KeyDecreaseAction();
 	
-	int		TranslateKey(unsigned char Key) const;
-	int		TranslateKeyDefault(unsigned char Key) const;
-	int		TranslateKeyModplug(unsigned char Key) const;
+	int		TranslateKey(Keycode Key) const;
+	int		TranslateKeyDefault(Keycode Key) const;
+	int		TranslateKeyModplug(Keycode Key) const;
 	
-	bool	CheckClearKey(unsigned char Key) const;
-	bool	CheckHaltKey(unsigned char Key) const;
-	bool	CheckReleaseKey(unsigned char Key) const;
-	bool	CheckRepeatKey(unsigned char Key) const;
-	bool	CheckEchoKey(unsigned char Key) const;		// // //
+	bool	CheckClearKey(Keycode Key) const;
+	bool	CheckHaltKey(Keycode Key) const;
+	bool	CheckReleaseKey(Keycode Key) const;
+	bool	CheckRepeatKey(Keycode Key) const;
+	bool	CheckEchoKey(Keycode Key) const;		// // //
 
-	bool	PreventRepeat(unsigned char Key, bool Insert);
-	void	RepeatRelease(unsigned char Key);
+	bool	PreventRepeat(Keycode Key, bool Insert);
+	void	RepeatRelease(Keycode Key);
 
-	bool	EditInstrumentColumn(stChanNote &Note, int Value, bool &StepDown, bool &MoveRight, bool &MoveLeft);
-	bool	EditVolumeColumn(stChanNote &Note, int Value, bool &bStepDown);
-	bool	EditEffNumberColumn(stChanNote &Note, unsigned char nChar, int EffectIndex, bool &bStepDown);
-	bool	EditEffParamColumn(stChanNote &Note, int Value, int EffectIndex, bool &bStepDown, bool &bMoveRight, bool &bMoveLeft);
+	bool	EditInstrumentColumn(stChanNote &Note, Keycode key, bool &StepDown, bool &MoveRight, bool &MoveLeft);
+	bool	EditVolumeColumn(stChanNote &Note, Keycode key, bool &bStepDown);
+	bool	EditEffNumberColumn(stChanNote &Note, Keycode key, int EffectIndex, bool &bStepDown);
+	bool	EditEffParamColumn(stChanNote &Note, Keycode key, int EffectIndex, bool &bStepDown, bool &bMoveRight, bool &bMoveLeft);
 
 	void	InsertNote(int Note, int Octave, int Channel, int Velocity);
 
 	// MIDI keyboard emulation
-	void	HandleKeyboardNote(char nChar, bool Pressed);
+	void	HandleKeyboardNote(Keycode key, bool Pressed);
 	bool	IsSplitEnabled(int MidiNote, int Channel) const;		// // //
 	void	SplitKeyboardAdjust(stChanNote &Note) const;		// // //
 	void	SplitAdjustChannel(unsigned int &Channel, const stChanNote &Note) const;		// // //
@@ -300,7 +303,7 @@ private:
 	int					m_iSplitInstrument;
 	int					m_iSplitTranspose;
 
-	std::unordered_map<unsigned char, int> m_iNoteCorrection;	// // // correction from changing octaves
+	std::unordered_map<Keycode, int> m_iNoteCorrection;			// // // correction from changing octaves
 	CNoteQueue			*m_pNoteQueue;							// // // Note queue for handling note triggers
 
 	// MIDI
@@ -344,8 +347,8 @@ public:
 	afx_msg BOOL OnEraseBkgnd(CDC* pDC);
 	afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
 	afx_msg void OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
-	afx_msg void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
-	afx_msg void OnKeyUp(UINT nChar, UINT nRepCnt, UINT nFlags);
+	afx_msg void OnKeyDown(UINT key, UINT nRepCnt, UINT nFlags);
+	afx_msg void OnKeyUp(UINT key, UINT nRepCnt, UINT nFlags);
 	afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
 	afx_msg void OnMouseMove(UINT nFlags, CPoint point);
 	afx_msg void OnXButtonDown(UINT nFlags, UINT nButton, CPoint point);		// // //
@@ -387,7 +390,7 @@ public:
 	afx_msg void OnTrackerToggleChannel();
 	afx_msg void OnTrackerSoloChannel();
 	afx_msg void OnTrackerUnmuteAllChannels();
-	afx_msg void OnSysKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
+	afx_msg void OnSysKeyDown(UINT key, UINT nRepCnt, UINT nFlags);
 	afx_msg void OnEditInterpolate();
 	afx_msg void OnEditReplaceInstrument();
 	afx_msg void OnEditReverse();

--- a/Source/FamiTrackerView.h
+++ b/Source/FamiTrackerView.h
@@ -39,7 +39,15 @@ class CFrameEditor;
 class Action;
 class CNoteQueue;		// // //
 
+// Keycode vs character
+
 using Keycode = int64_t;// int
+using Character = uint64_t;
+
+enum class KeyType {
+	KEYCODE,
+	CHARACTER
+};
 
 // TODO move general tracker state variables to the mainframe instead of the view, such as selected octave, instrument etc
 
@@ -170,7 +178,7 @@ private:
 	void	StepDown();
 
 	// Input key handling
-	void	HandleKeyboardInput(Keycode Key);		// // //
+	void HandleKeyboardInput(Keycode Key, KeyType type);		// // //
 	void	TranslateMidiMessage();
 
 	void	OnKeyDirUp();
@@ -206,7 +214,7 @@ private:
 
 	bool	EditInstrumentColumn(stChanNote &Note, Keycode key, bool &StepDown, bool &MoveRight, bool &MoveLeft);
 	bool	EditVolumeColumn(stChanNote &Note, Keycode key, bool &bStepDown);
-	bool	EditEffNumberColumn(stChanNote &Note, Keycode key, int EffectIndex, bool &bStepDown);
+	bool EditEffNumberColumn(stChanNote &Note, Keycode key, KeyType type, int EffectIndex, bool &bStepDown);
 	bool	EditEffParamColumn(stChanNote &Note, Keycode key, int EffectIndex, bool &bStepDown, bool &bMoveRight, bool &bMoveLeft);
 
 	void	InsertNote(int Note, int Octave, int Channel, int Velocity);
@@ -290,7 +298,7 @@ private:
 	unsigned int		m_iWindowHeight;						// Height of view area
 
 	// Input
-	char				m_cKeyList[256];
+	char				m_cKeyList[256];	// TODO unordered_set<Keycode> keysHeldDown;
 	unsigned int		m_iKeyboardNote;
 	int					m_iLastNote;							// Last note added to pattern
 	int					m_iLastInstrument;						// Last instrument added to pattern
@@ -348,6 +356,7 @@ public:
 	afx_msg void OnLButtonDown(UINT nFlags, CPoint point);
 	afx_msg void OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 	afx_msg void OnKeyDown(UINT key, UINT nRepCnt, UINT nFlags);
+	afx_msg void OnChar(UINT nChar, UINT nRepCnt, UINT nFlags);
 	afx_msg void OnKeyUp(UINT key, UINT nRepCnt, UINT nFlags);
 	afx_msg BOOL OnMouseWheel(UINT nFlags, short zDelta, CPoint pt);
 	afx_msg void OnMouseMove(UINT nFlags, CPoint point);

--- a/Source/FamiTrackerView.h
+++ b/Source/FamiTrackerView.h
@@ -241,15 +241,6 @@ private:
 	bool	IsShiftPressed() const;
 	bool	IsControlPressed() const;
 
-	// Update timer
-#if 0
-	static UINT ThreadProcFunc(LPVOID pParam);
-
-	bool	StartTimerThread();
-	void	EndTimerThread();
-	UINT	ThreadProc();
-#endif
-
 //
 // Constants
 //

--- a/Source/PatternEditor.cpp
+++ b/Source/PatternEditor.cpp
@@ -1328,7 +1328,7 @@ void CPatternEditor::DrawCell(CDC *pDC, int PosX, cursor_column_t Column, int Ch
 
 	const CTrackerChannel *pTrackerChannel = m_pDocument->GetChannel(Channel);
 
-	int EffNumber = Column >= 4 ? pNoteData->EffNumber[(Column - 4) / 3] : 0;		// // //
+	effect_t EffNumber = Column >= 4 ? pNoteData->EffNumber[(Column - 4) / 3] : EF_NONE;		// // //
 	int EffParam  = Column >= 4 ? pNoteData->EffParam[(Column - 4) / 3] : 0;
 
 	// Detect invalid note data

--- a/Source/TrackerChannel.cpp
+++ b/Source/TrackerChannel.cpp
@@ -24,6 +24,7 @@
 #include "PatternNote.h"		// // //
 #include "Instrument.h"		// // //
 #include "TrackerChannel.h"
+#include <stdexcept>
 
 /*
  * This class serves as the interface between the UI and the sound player for each channel
@@ -167,7 +168,7 @@ bool CTrackerChannel::IsInstrumentCompatible(int Instrument, inst_type_t Type) c
 	return false;
 }
 
-bool CTrackerChannel::IsEffectCompatible(int EffNumber, int EffParam) const		// // //
+bool CTrackerChannel::IsEffectCompatible(effect_t EffNumber, int EffParam) const
 {
 	switch (EffNumber) {
 		case EF_NONE:

--- a/Source/TrackerChannel.cpp
+++ b/Source/TrackerChannel.cpp
@@ -207,6 +207,11 @@ bool CTrackerChannel::IsEffectCompatible(effect_t EffNumber, int EffParam) const
 			return m_iChip == SNDCHIP_FDS && (EffParam <= 0x7F || EffParam == 0xE0);
 		case EF_VRC7_PORT: case EF_VRC7_WRITE:		// // // 050B
 			return m_iChip == SNDCHIP_VRC7;
+		case EF_PHASE_RESET:
+			return this->m_iChip == SNDCHIP_VRC6 && EffParam == 0x00;
+		case EF_COUNT:
+		default:
+			throw std::runtime_error("Missing case in CTrackerChannel::IsEffectCompatible");
 	}
 
 	return false;

--- a/Source/TrackerChannel.h
+++ b/Source/TrackerChannel.h
@@ -27,6 +27,7 @@
 
 #include <afxmt.h>	// For CMutex
 #include "APU/Types.h"		// // //
+#include "FamiTrackerTypes.h"
 
 enum note_prio_t {
 	NOTE_PRIO_0, 
@@ -58,7 +59,7 @@ public:
 	int GetPitch() const;
 
 	bool IsInstrumentCompatible(int Instrument, inst_type_t Type) const;		// // //
-	bool IsEffectCompatible(int EffNumber, int EffParam) const;		// // //
+	bool IsEffectCompatible(effect_t EffNumber, int EffParam) const;		// // //
 
 private:
 	LPCTSTR m_pChannelName, m_pShortName;		// // //

--- a/Source/utils/input.h
+++ b/Source/utils/input.h
@@ -7,70 +7,16 @@
 
 // Keycode vs character
 
+namespace ts = type_safe;
+
 using Keycode = int64_t;// int
 
-namespace input {
-	using namespace type_safe;
-	struct Character : strong_typedef<Character, int>,
-		strong_typedef_op::equality_comparison<Character>,
-		strong_typedef_op::relational_comparison<Character>
-	{
-		using strong_typedef::strong_typedef;
-	};
-}
-using input::Character;
+struct Character : ts::strong_typedef<Character, int>,
+	ts::strong_typedef_op::equality_comparison<Character>,
+	ts::strong_typedef_op::relational_comparison<Character>
+{
+	using strong_typedef::strong_typedef;
+};
 
 
-// Input class
 using Input = std::variant<Keycode, Character>;
-
-template<typename T, typename Variant>
-bool is(Variant v) {
-	return std::holds_alternative<T>(
-		std::forward<Variant>(v)
-	);
-}
-
-using std::get;
-using std::get_if;
-
-
-
-//class Input {
-//private:
-//	union {
-//		Keycode keycode;
-//		Character character;
-//	};
-
-//	enum InputType {
-//		KEYCODE,
-//		CHARACTER
-//	};
-//	InputType type;
-//	
-//public:
-//	Input(Keycode k) {
-//		keycode = k;
-//		type = KEYCODE;
-//	}
-//	Input(Character c) {
-//		character = c;
-//		type = CHARACTER;
-//	}
-
-//	bool isChar() {
-//		return type == CHARACTER;
-//	}
-//	Character getChar() {
-//		return character;
-//	}
-
-//	bool isKey() {
-//		return type == KEYCODE;
-//	}
-//	Keycode getKey() {
-//		return keycode;
-//	}
-//};
-

--- a/Source/utils/input.h
+++ b/Source/utils/input.h
@@ -9,7 +9,7 @@
 
 namespace ts = type_safe;
 
-using Keycode = int64_t;// int
+using Keycode = int;
 
 struct Character : ts::strong_typedef<Character, int>,
 	ts::strong_typedef_op::equality_comparison<Character>,


### PR DESCRIPTION
- [x] PR 1: type_safe
- [x] PR 2: =00

-------

- [x] Add non-alphanumeric input system
- [x] Add =00 effect
- [x] Make it not red.
- [x] Make it reset phase.

Bugs:

- [x] Fixed: Using \` in note column causes spurious undo.