### PR TITLE
(wip) Move cursor right when typing in effect columns

### DIFF
--- a/Source/FamiTrackerView.cpp
+++ b/Source/FamiTrackerView.cpp
@@ -3046,8 +3046,15 @@ void CFamiTrackerView::HandleKeyboardInput(unsigned char nChar)		// // //
 				m_pPatternEditor->MoveLeft();
 			if (bMoveRight)
 				m_pPatternEditor->MoveRight();
-			if (bStepDown)
-				StepDown();
+			if (bStepDown) {
+				// FIXME option
+				if (true && Column >= C_EFF1_NUM && Column <= C_EFF1_PARAM2) {
+					m_pPatternEditor->MoveRight();
+				} // else if (something && Column == C_EFF1_PARAM2) {}
+				else {
+					StepDown();
+				}
+			}
 			InvalidateCursor();
 			pAction->SaveRedoState(static_cast<CMainFrame*>(GetParentFrame()));		// // //
 		}


### PR DESCRIPTION
No GUI toggle yet.

Fixes https://github.com/jimbo1qaz/0CC-FamiTracker/issues/71