### PR TITLE
[5B] Fix bug where non-noise instruments overwrite noise period

### DIFF
--- a/Source/ChannelsS5B.cpp
+++ b/Source/ChannelsS5B.cpp
@@ -164,7 +164,18 @@ bool CChannelHandlerS5B::HandleEffect(effect_t EffNum, EffParamT EffParam)
 void CChannelHandlerS5B::HandleNote(int Note, int Octave)		// // //
 {
 	CChannelHandler::HandleNote(Note, Octave);
-	m_iNoiseFreq = m_iDefaultNoise;
+
+	/*
+	Vxx is handled above: CChannelHandlerS5B::HandleEffect, case EF_DUTY_CYCLE
+	m_iDefaultDuty is Vxx.
+	m_iDutyPeriod is Vxx plus instrument bit-flags. But it's not fully
+		initialized yet (instruments are handled after notes) which is bad.
+	https://docs.google.com/document/d/e/2PACX-1vQ8osh6mm4c4Ay_gVMIJCH8eRB5gBE180Xyeda1T5U6owG7BbKM-yNKVB8azg27HUD9QZ9Vf88crplE/pub
+	*/
+
+	if (this->m_iDefaultDuty & DutyType::NOISE) {
+		m_iNoiseFreq = m_iDefaultNoise;
+	}
 }
 
 void CChannelHandlerS5B::HandleEmptyNote()

--- a/Source/ChannelsS5B.cpp
+++ b/Source/ChannelsS5B.cpp
@@ -108,18 +108,10 @@ CChannelHandlerS5B::CChannelHandlerS5B() :
 
 
 using EffParamT = unsigned char;
-enum DutyType {
-	TONE		= 1<<6,
-	NOISE		= 1<<7,
-	ENVELOPE	= 1<<5,
-};
-
-
-
-static const std::map<EffParamT, DutyType> VXX_TO_DUTY = {
-	{1<<0, DutyType::TONE},
-	{1<<1, DutyType::NOISE},
-	{1<<2, DutyType::ENVELOPE},
+static const std::map<EffParamT, s5b_mode_t> VXX_TO_DUTY = {
+	{1<<0, S5B_MODE_SQUARE},
+	{1<<1, S5B_MODE_NOISE},
+	{1<<2, S5B_MODE_ENVELOPE},
 };
 
 bool CChannelHandlerS5B::HandleEffect(effect_t EffNum, EffParamT EffParam)
@@ -173,7 +165,7 @@ void CChannelHandlerS5B::HandleNote(int Note, int Octave)		// // //
 	https://docs.google.com/document/d/e/2PACX-1vQ8osh6mm4c4Ay_gVMIJCH8eRB5gBE180Xyeda1T5U6owG7BbKM-yNKVB8azg27HUD9QZ9Vf88crplE/pub
 	*/
 
-	if (this->m_iDefaultDuty & DutyType::NOISE) {
+	if (this->m_iDefaultDuty & S5B_MODE_NOISE) {
 		s_iNoiseFreq = s_iDefaultNoise;
 	}
 }

--- a/Source/ChannelsS5B.cpp
+++ b/Source/ChannelsS5B.cpp
@@ -134,8 +134,14 @@ bool CChannelHandlerS5B::HandleEffect(effect_t EffNum, EffParamT EffParam)
 		m_iAutoEnvelopeShift = EffParam >> 4;
 		break;
 	case EF_DUTY_CYCLE: {
-		// Translate Vxx bitmask to `enum DutyType` bitmask,
-		// using VXX_TO_DUTY as a conversion table.
+		/*
+		Translate Vxx bitmask to `enum DutyType` bitmask, using VXX_TO_DUTY
+		as a conversion table.
+
+		CSeqInstHandlerS5B::ProcessSequence loads m_iDutyPeriod from the top
+		3 bits of an instrument's duty sequence. (The bottom 5 go to m_iNoiseFreq.)
+		This function moves Vxx to the top 3 bits of m_iDutyPeriod.
+		*/
 
 		unsigned char duty = 0;
 		for (auto const&[VXX, DUTY] : VXX_TO_DUTY) {

--- a/Source/ChannelsS5B.h
+++ b/Source/ChannelsS5B.h
@@ -59,15 +59,15 @@ protected:
 
 	// Static memebers
 protected:
-	static int s_iModes;
-	static int s_iNoiseFreq;
-	static int s_iNoisePrev;		// // //
-	static int s_iDefaultNoise;		// // //
-	static unsigned char s_iEnvFreqHi;
-	static unsigned char s_iEnvFreqLo;
-	static bool s_bEnvTrigger;		// // // 050B
-	static int s_iEnvType;
-	static int s_unused;		// // // 050B, unused
+	static int m_iModes;
+	static int m_iNoiseFreq;
+	static int m_iNoisePrev;		// // //
+	static int m_iDefaultNoise;		// // //
+	static unsigned char m_iEnvFreqHi;
+	static unsigned char m_iEnvFreqLo;
+	static bool m_bEnvTrigger;		// // // 050B
+	static int m_iEnvType;
+	static int m_i5808B4;		// // // 050B, unused
 
 	// Instance members
 protected:

--- a/Source/ChannelsS5B.h
+++ b/Source/ChannelsS5B.h
@@ -59,15 +59,15 @@ protected:
 
 	// Static memebers
 protected:
-	static int m_iModes;
-	static int m_iNoiseFreq;
-	static int m_iNoisePrev;		// // //
-	static int m_iDefaultNoise;		// // //
-	static unsigned char m_iEnvFreqHi;
-	static unsigned char m_iEnvFreqLo;
-	static bool m_bEnvTrigger;		// // // 050B
-	static int m_iEnvType;
-	static int m_i5808B4;		// // // 050B, unused
+	static int s_iModes;
+	static int s_iNoiseFreq;
+	static int s_iNoisePrev;		// // //
+	static int s_iDefaultNoise;		// // //
+	static unsigned char s_iEnvFreqHi;
+	static unsigned char s_iEnvFreqLo;
+	static bool s_bEnvTrigger;		// // // 050B
+	static int s_iEnvType;
+	static int s_unused;		// // // 050B, unused
 
 	// Instance members
 protected:

--- a/Source/SeqInstHandlerS5B.cpp
+++ b/Source/SeqInstHandlerS5B.cpp
@@ -31,8 +31,15 @@ bool CSeqInstHandlerS5B::ProcessSequence(int Index, unsigned Setting, int Value)
 	case SEQ_DUTYCYCLE:
 		if (auto pChan = dynamic_cast<CChannelHandlerInterfaceS5B*>(m_pInterface)) {
 			m_pInterface->SetDutyPeriod(Value & 0xE0);
-			pChan->SetNoiseFreq(Value & 0x1F);
+
+			if (Value & S5B_MODE_NOISE) {
+				pChan->SetNoiseFreq(Value & 0x1F);
+			}
+			
 			return true;
+			
+			// In chips other than 5B: case SEQ_DUTYCYCLE:
+			// m_pInterface->SetDutyPeriod(Value);
 		}
 	}
 	return CSeqInstHandler::ProcessSequence(Index, Setting, Value);


### PR DESCRIPTION
- [x] When Vxx & 02 is inactive, ensure Wxx is not applied on new notes, whether Wxx != 0.
- [x] Ensure instrument sequences don't write noise if noise bit unset.
    - `bool CSeqInstHandlerS5B::ProcessSequence(int Index, unsigned Setting, int Value)` writes even if noise disabled. Function ∄ in 0.3.14.4.

Fixes #1.

Explicit Wxx commands are *always* applied when they occur, but noise instruments on same+ columns overwrite them.

See https://github.com/jimbo1qaz/0CC-FamiTracker/wiki/5B-noise-period-overwritten and https://docs.google.com/document/d/e/2PACX-1vQ8osh6mm4c4Ay_gVMIJCH8eRB5gBE180Xyeda1T5U6owG7BbKM-yNKVB8azg27HUD9QZ9Vf88crplE/pub