### PR TITLE
Strict Vxx effect validation

### DIFF
--- a/Source/ChannelHandler.cpp
+++ b/Source/ChannelHandler.cpp
@@ -1006,6 +1006,11 @@ int CChannelHandler::GetDutyPeriod() const
 	return m_iDutyPeriod;
 }
 
+int CChannelHandler::getDutyMax() const {
+	return -1;
+}
+
+
 unsigned char CChannelHandler::GetArpParam() const
 {
 	return m_iEffect == EF_ARPEGGIO ? m_iEffectParam : 0U;

--- a/Source/ChannelHandler.h
+++ b/Source/ChannelHandler.h
@@ -320,6 +320,7 @@ public:		// // //
 	/*!	\brief Obtains the current channel volume.
 		\return The channel volume level. */
 	virtual int GetChannelVolume() const;
+
 	/*!	\brief Sets the current duty cycle value of the channel.
 		\details The value received by the channel is converted according to the current instrument type.
 		\param Duty The duty cycle value. */
@@ -327,6 +328,13 @@ public:		// // //
 	/*!	\brief Obtains the current duty cycle value of the channel.
 		\return The duty cycle value. */
 	int		GetDutyPeriod() const;
+	/*!
+	 * Returns maximum valid duty cycle, inclusive (-1 if none are valid).
+	 * Used to mark invalid Vxx red in the GUI.
+	 * @return Valid duty cycles are 0 <= duty <= getDutyMax().
+	 */
+	virtual int getDutyMax() const;
+
 	unsigned char GetArpParam() const;		// // //
 	bool	IsActive() const;
 	bool	IsReleasing() const;

--- a/Source/Channels2A03.cpp
+++ b/Source/Channels2A03.cpp
@@ -38,7 +38,7 @@
 
 //#define NOISE_PITCH_SCALE
 
-CChannelHandler2A03::CChannelHandler2A03() : 
+CChannelHandler2A03::CChannelHandler2A03() :
 	CChannelHandler(0x7FF, 0x0F),
 	m_bHardwareEnvelope(false),
 	m_bEnvelopeLoop(true),
@@ -144,11 +144,17 @@ C2A03Square::C2A03Square() :
 {
 }
 
+const char C2A03Square::MAX_DUTY = 0x03;
+
+int C2A03Square::getDutyMax() const {
+	return static_cast<int>(MAX_DUTY);
+}
+
 void C2A03Square::RefreshChannel()
 {
 	int Period = CalculatePeriod();
 	int Volume = CalculateVolume();
-	char DutyCycle = (m_iDutyPeriod & 0x03);
+	char DutyCycle = (m_iDutyPeriod & MAX_DUTY);
 
 	unsigned char HiFreq = (Period & 0xFF);
 	unsigned char LoFreq = (Period >> 8);

--- a/Source/Channels2A03.cpp
+++ b/Source/Channels2A03.cpp
@@ -431,11 +431,17 @@ int CNoiseChan::LimitRawPeriod(int Period) const		// // //
 	return Period; // no limit
 }
 
+const char CNoiseChan::MAX_DUTY = 0x01;
+
+int CNoiseChan::getDutyMax() const {
+	return MAX_DUTY;
+}
+
 void CNoiseChan::RefreshChannel()
 {
 	int Period = CalculatePeriod();
 	int Volume = CalculateVolume();
-	char NoiseMode = (m_iDutyPeriod & 0x01) << 7;
+	char NoiseMode = (m_iDutyPeriod & MAX_DUTY) << 7;
 
 	Period = Period & 0x0F;
 	Period ^= 0x0F;

--- a/Source/Channels2A03.cpp
+++ b/Source/Channels2A03.cpp
@@ -36,8 +36,6 @@
 #include "SeqInstHandler.h"		// // //
 #include "InstHandlerDPCM.h"		// // //
 
-//#define NOISE_PITCH_SCALE
-
 CChannelHandler2A03::CChannelHandler2A03() :
 	CChannelHandler(0x7FF, 0x0F),
 	m_bHardwareEnvelope(false),
@@ -433,29 +431,13 @@ int CNoiseChan::LimitRawPeriod(int Period) const		// // //
 	return Period; // no limit
 }
 
-/*
-int CNoiseChan::CalculatePeriod() const
-{
-	return LimitPeriod(m_iPeriod - GetVibrato() + GetFinePitch() + GetPitch());
-}
-*/
-
-CNoiseChan::CNoiseChan() : CChannelHandler2A03()		// // //
-{
-}
-
 void CNoiseChan::RefreshChannel()
 {
 	int Period = CalculatePeriod();
 	int Volume = CalculateVolume();
 	char NoiseMode = (m_iDutyPeriod & 0x01) << 7;
 
-#ifdef NOISE_PITCH_SCALE
-	Period = (Period >> 4) & 0x0F;
-#else
 	Period = Period & 0x0F;
-#endif
-
 	Period ^= 0x0F;
 	
 	if (m_bGate)		// // //
@@ -492,23 +474,8 @@ CString CNoiseChan::GetCustomEffectString() const		// // //
 
 int CNoiseChan::TriggerNote(int Note)
 {
-	// Clip range to 0-15
-	/*
-	if (Note > 0x0F)
-		Note = 0x0F;
-	if (Note < 0)
-		Note = 0;
-		*/
-
 	RegisterKeyState(Note);
-
-//	Note &= 0x0F;
-
-#ifdef NOISE_PITCH_SCALE
-	return (Note ^ 0x0F) << 4;
-#else
 	return Note | 0x100;		// // //
-#endif
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/Channels2A03.h
+++ b/Source/Channels2A03.h
@@ -92,7 +92,10 @@ private:
 class CNoiseChan : public CChannelHandler2A03 {
 public:
 	void	RefreshChannel();
+	int getDutyMax() const override;
 protected:
+	static const char MAX_DUTY;
+
 	void	ClearRegisters() override;
 	CString	GetCustomEffectString() const override;		// // //
 	void	HandleNote(int Note, int Octave) override;

--- a/Source/Channels2A03.h
+++ b/Source/Channels2A03.h
@@ -91,7 +91,6 @@ private:
 // Noise
 class CNoiseChan : public CChannelHandler2A03 {
 public:
-	CNoiseChan();
 	void	RefreshChannel();
 protected:
 	void	ClearRegisters() override;

--- a/Source/Channels2A03.h
+++ b/Source/Channels2A03.h
@@ -53,7 +53,10 @@ public:
 	C2A03Square();
 	void	RefreshChannel() override;
 	void	SetChannelID(int ID) override;		// // //
+	int getDutyMax() const override;
 protected:
+	static const char MAX_DUTY;
+
 	int		ConvertDuty(int Duty) const override;		// // //
 	void	ClearRegisters() override;
 

--- a/Source/ChannelsMMC5.cpp
+++ b/Source/ChannelsMMC5.cpp
@@ -116,11 +116,17 @@ void CChannelHandlerMMC5::ResetChannel()
 // // // MMC5 Channels
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+const char CChannelHandlerMMC5::MAX_DUTY = 0x03;
+
+int CChannelHandlerMMC5::getDutyMax() const {
+	return MAX_DUTY;
+}
+
 void CChannelHandlerMMC5::RefreshChannel()		// // //
 {
 	int Period = CalculatePeriod();
 	int Volume = CalculateVolume();
-	char DutyCycle = (m_iDutyPeriod & 0x03);
+	char DutyCycle = (m_iDutyPeriod & MAX_DUTY);
 
 	unsigned char HiFreq		= (Period & 0xFF);
 	unsigned char LoFreq		= (Period >> 8);

--- a/Source/ChannelsMMC5.h
+++ b/Source/ChannelsMMC5.h
@@ -31,8 +31,10 @@ public:
 	CChannelHandlerMMC5();
 	void	ResetChannel() override;
 	void	RefreshChannel() override;
-
+	int getDutyMax() const override;
 protected:
+	static const char MAX_DUTY;
+
 	void	HandleNoteData(stChanNote *pNoteData, int EffColumns) override;
 	bool	HandleEffect(effect_t EffNum, unsigned char EffParam) override;		// // //
 	void	HandleEmptyNote() override;

--- a/Source/ChannelsN163.cpp
+++ b/Source/ChannelsN163.cpp
@@ -226,6 +226,10 @@ void CChannelHandlerN163::SetChannelCount(int Count)		// // //
 	m_iChannels = Count;
 }
 
+int CChannelHandlerN163::getDutyMax() const {
+	return CInstrumentN163::MAX_WAVE_COUNT - 1;
+}
+
 int CChannelHandlerN163::ConvertDuty(int Duty) const		// // //
 {
 	switch (m_iInstTypeCurrent) {

--- a/Source/ChannelsN163.h
+++ b/Source/ChannelsN163.h
@@ -39,6 +39,8 @@ public:
 
 	void	SetChannelCount(int Count);		// // //
 
+	int getDutyMax() const override;
+
 protected:
 	bool	HandleEffect(effect_t EffNum, unsigned char EffParam) override;		// // //
 	bool	HandleInstrument(bool Trigger, bool NewInstrument) override;		// // //

--- a/Source/ChannelsS5B.cpp
+++ b/Source/ChannelsS5B.cpp
@@ -114,6 +114,13 @@ static const std::map<EffParamT, s5b_mode_t> VXX_TO_DUTY = {
 	{1<<2, S5B_MODE_ENVELOPE},
 };
 
+const char CChannelHandlerS5B::MAX_DUTY = 0x07;		// = 1|2|4
+
+int CChannelHandlerS5B::getDutyMax() const {
+	return MAX_DUTY;
+}
+
+
 bool CChannelHandlerS5B::HandleEffect(effect_t EffNum, EffParamT EffParam)
 {
 	switch (EffNum) {

--- a/Source/ChannelsS5B.h
+++ b/Source/ChannelsS5B.h
@@ -36,7 +36,7 @@ public:
 
 	int getDutyMax() const override;
 protected:
-	static const char MAX_DUTY;
+	static const char MAX_DUTY;		// TODO remove class constant, move to .cpp file
 
 	bool	HandleEffect(effect_t EffNum, unsigned char EffParam) override;		// // //
 	void	HandleNote(int Note, int Octave) override;		// // //

--- a/Source/ChannelsS5B.h
+++ b/Source/ChannelsS5B.h
@@ -34,8 +34,10 @@ public:
 
 	void	SetNoiseFreq(int Pitch) override final;		// // //
 
+	int getDutyMax() const override;
 protected:
-	// // //
+	static const char MAX_DUTY;
+
 	bool	HandleEffect(effect_t EffNum, unsigned char EffParam) override;		// // //
 	void	HandleNote(int Note, int Octave) override;		// // //
 	void	HandleEmptyNote() override;

--- a/Source/ChannelsVRC6.cpp
+++ b/Source/ChannelsVRC6.cpp
@@ -151,6 +151,12 @@ int CVRC6Square::ConvertDuty(int Duty) const		// // //
 // VRC6 Sawtooth
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+const char CVRC6Sawtooth::MAX_DUTY = 0x01;
+
+int CVRC6Sawtooth::getDutyMax() const {
+	return MAX_DUTY;
+}
+
 void CVRC6Sawtooth::RefreshChannel()
 {
 	if (!m_bGate) {		// // //

--- a/Source/ChannelsVRC6.cpp
+++ b/Source/ChannelsVRC6.cpp
@@ -111,6 +111,12 @@ void CChannelHandlerVRC6::resetPhase()		// // //
 // // // VRC6 Squares
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+const char CVRC6Square::MAX_DUTY = 0x07;
+
+int CVRC6Square::getDutyMax() const {
+	return MAX_DUTY;
+}
+
 void CVRC6Square::RefreshChannel()
 {
 	uint16_t Address = this->getAddress();

--- a/Source/ChannelsVRC6.h
+++ b/Source/ChannelsVRC6.h
@@ -58,7 +58,10 @@ class CVRC6Sawtooth : public CChannelHandlerVRC6 {
 public:
 	CVRC6Sawtooth() : CChannelHandlerVRC6(0xFFF, 0x3F) { }
 	void	RefreshChannel() override;
+	int getDutyMax() const override;
 protected:
+	static const char MAX_DUTY;
+
 	bool	CreateInstHandler(inst_type_t Type) override;		// // //
 	int		CalculateVolume() const override;
 };

--- a/Source/ChannelsVRC6.h
+++ b/Source/ChannelsVRC6.h
@@ -47,7 +47,10 @@ class CVRC6Square : public CChannelHandlerVRC6 {
 public:
 	CVRC6Square() : CChannelHandlerVRC6(0xFFF, 0x0F) { }
 	void	RefreshChannel() override;
+	int getDutyMax() const override;
 protected:
+	static const char MAX_DUTY;
+
 	int		ConvertDuty(int Duty) const override;		// // //
 };
 

--- a/Source/ChannelsVRC6.h
+++ b/Source/ChannelsVRC6.h
@@ -49,7 +49,7 @@ public:
 	void	RefreshChannel() override;
 	int getDutyMax() const override;
 protected:
-	static const char MAX_DUTY;
+	static const char MAX_DUTY;		// TODO remove class constant, move to .cpp file
 
 	int		ConvertDuty(int Duty) const override;		// // //
 };
@@ -60,7 +60,7 @@ public:
 	void	RefreshChannel() override;
 	int getDutyMax() const override;
 protected:
-	static const char MAX_DUTY;
+	static const char MAX_DUTY;		// TODO remove class constant, move to .cpp file
 
 	bool	CreateInstHandler(inst_type_t Type) override;		// // //
 	int		CalculateVolume() const override;

--- a/Source/ChannelsVRC7.cpp
+++ b/Source/ChannelsVRC7.cpp
@@ -263,6 +263,12 @@ int CChannelHandlerVRC7::CalculatePeriod() const
 // VRC7 Channels
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+const char CVRC7Channel::MAX_DUTY = 0x0F;
+
+int CVRC7Channel::getDutyMax() const {
+	return MAX_DUTY;
+}
+
 void CVRC7Channel::RefreshChannel()
 {	
 //	int Note = m_iTriggeredNote;

--- a/Source/ChannelsVRC7.h
+++ b/Source/ChannelsVRC7.h
@@ -88,7 +88,11 @@ class CVRC7Channel : public CChannelHandlerVRC7 {
 public:
 	CVRC7Channel() : CChannelHandlerVRC7() { }
 	void RefreshChannel();
+
+	int getDutyMax() const override;
 protected:
+	static const char MAX_DUTY;
+
 	void ClearRegisters();
 private:
 	void RegWrite(unsigned char Reg, unsigned char Value);

--- a/Source/ChannelsVRC7.h
+++ b/Source/ChannelsVRC7.h
@@ -91,7 +91,7 @@ public:
 
 	int getDutyMax() const override;
 protected:
-	static const char MAX_DUTY;
+	static const char MAX_DUTY;		// TODO remove class constant, move to .cpp file
 
 	void ClearRegisters();
 private:

--- a/Source/TrackerChannel.cpp
+++ b/Source/TrackerChannel.cpp
@@ -24,6 +24,9 @@
 #include "PatternNote.h"		// // //
 #include "Instrument.h"		// // //
 #include "TrackerChannel.h"
+
+#include "ChannelFactory.h"
+#include "ChannelHandler.h"
 #include <stdexcept>
 
 /*
@@ -213,8 +216,14 @@ bool CTrackerChannel::IsEffectCompatible(effect_t EffNumber, int EffParam) const
 			}
 			return EffParam <= limit;
 		}
-		case EF_DUTY_CYCLE:
-			return m_iChannelID != CHANID_DPCM;		// // // 050B
+		case EF_DUTY_CYCLE: {
+			static CChannelFactory F;
+			// Don't use make_unique if you need a custom deleter or are adopting a raw pointer from elsewhere.
+
+			auto channelHandler = std::unique_ptr<CChannelHandler>(F.Produce(this->m_iChannelID));
+			int limit = channelHandler->getDutyMax();
+			return EffParam <= limit;
+		}
 		case EF_FDS_MOD_DEPTH:
 			return m_iChip == SNDCHIP_FDS && (EffParam <= 0x3F || EffParam >= 0x80);
 		case EF_FDS_MOD_SPEED_HI: case EF_FDS_MOD_SPEED_LO: case EF_FDS_MOD_BIAS:
@@ -237,13 +246,3 @@ bool CTrackerChannel::IsEffectCompatible(effect_t EffNumber, int EffParam) const
 
 	return false;
 }
-
-/*
-int CTrackerChannel::GetEffect(int Letter) const
-{
-	if (m_iChip == SNDCHIP_FDS) {
-	}
-
-	return 
-}
-*/


### PR DESCRIPTION
Validate Vxx values using channel-specific limits.

Each channel's limit type is stored within its subclass of CChannelHandler. To edit Vxx limit for new channel types, add `int CChannelHandlerXYZ::getDutyMax() const override`.

- [ ] Profile to ensure no performance issues when rendering thousands of Vxx
    - While profiling a debug build, opening [All Expansions, Max Effects.zip](https://github.com/jimbo1qaz/0CC-FamiTracker/files/2162303/All.Expansions.Max.Effects.zip), and PageUp/Down between the data's beginning and end, 15% of time is spent in `CTrackerChannel::IsEffectCompatible`.
    - While running a release build, Page Down continuously, Vxx CPU usage is less than Gxx.